### PR TITLE
MatchOptions & OptionalMatchRelationship

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -1,9 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <!--<config>
-    <add key="DefaultPushSource" value="https://www.myget.org/F/neo4jclient-extension-tx/api/v2/package" />
-  </config>-->
-    
+  
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A relationship might be setup like this:
                 .MergeOnMatchOrCreate(hr => hr.DateEffective)
                 .Set();
 
-The address entity undergoes a similar setup - see the [unit tests](https://github.com/simonpinn/Neo4jClient.Extension/blob/master/src/Neo4jClient.Extension.Test.Common/Neo/NeoConfig.cs) for the complete setup.
+The address entity undergoes a similar setup - see the [unit tests](https://github.com/simonpinn/Neo4jClient.Extension/blob/master/test/Neo4jClient.Extension.Test.Common/Neo/NeoConfig.cs) for the complete setup.
 
 ##Fluent Config Usage##
 Now that our model is configured, creating a weapon is as simple as:

--- a/SolutionItems/Properties/AssemblyInfoGlobal.cs
+++ b/SolutionItems/Properties/AssemblyInfoGlobal.cs
@@ -4,10 +4,10 @@ using System.Runtime.InteropServices;
 
 
 [assembly: AssemblyCopyright("Copyright © 2014")]
-[assembly: AssemblyVersion("0.1.3.0")]
+[assembly: AssemblyVersion("0.1.3.1")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
-[assembly: AssemblyInformationalVersion("0.1.3.0-beta")]    // trigger pre release package
+[assembly: AssemblyInformationalVersion("0.1.3.1-beta")]    // trigger pre release package
 #else
     [assembly: AssemblyConfiguration("Release")]
 #endif

--- a/src/Neo4jClient.Extension/Cypher/Extension/CypherExtension.Main.cs
+++ b/src/Neo4jClient.Extension/Cypher/Extension/CypherExtension.Main.cs
@@ -15,20 +15,47 @@ namespace Neo4jClient.Extension.Cypher
         public static CypherExtensionContext DefaultExtensionContext = new CypherExtensionContext();
         private static readonly Dictionary<Type, string> EntityLabelCache = new Dictionary<Type, string>();
         
-        public static ICypherFluentQuery MatchEntity<T>(this ICypherFluentQuery query, T entity, string paramKey = null, string preCql = "", string postCql = "", List<CypherProperty> propertyOverride = null) where T : class
+        public static ICypherFluentQuery MatchEntity<T>(this ICypherFluentQuery query, T entity, string identifier = null, string preCql = "", string postCql = "", List<CypherProperty> propertyOverride = null) where T : class
         {
-            paramKey = entity.EntityParamKey(paramKey);
-            var matchCypher = entity.ToCypherString<T, CypherMatchAttribute>(CypherExtensionContext.Create(query), paramKey, propertyOverride);
-            var cql = string.Format("{0}({1}){2}", preCql, matchCypher, postCql);
-            //create a dynamic object for the type
-            dynamic cutdown = entity.CreateDynamic(propertyOverride ?? CypherTypeItemHelper.PropertiesForPurpose<T, CypherMatchAttribute>(entity));
-
-            var matchKey = GetMatchParamName(paramKey);
-
-            return query
-                .Match(cql)
-                .WithParam(matchKey, cutdown);
+            var options = new MatchOptions
+            {
+                Identifier = identifier,
+                PreCql = preCql,
+                PostCql = postCql,
+                PropertyOverride = propertyOverride
+            };
+            return MatchEntity(query, entity, options);
         }
+
+        public static ICypherFluentQuery MatchEntity<T>(this ICypherFluentQuery query, T entity, MatchOptions options)
+            where T : class
+        {
+            return MatchWorker(query, entity, options, (q, s) => q.Match(s));
+        }
+
+        public static ICypherFluentQuery OptionalMatchEntity<T>(this ICypherFluentQuery query, T entity, MatchOptions options= null)
+           where T : class
+        {
+            if (options == null)
+            {
+                options = new MatchOptions();
+            }
+            return MatchWorker(query, entity, options, (q, s) => q.OptionalMatch(s));
+        }
+
+        private static ICypherFluentQuery MatchWorker<T>(this ICypherFluentQuery query, T entity, MatchOptions options, Func<ICypherFluentQuery, string, ICypherFluentQuery> matchFunction) where T : class
+        {
+            var identifier = entity.EntityParamKey(options.Identifier);
+            var matchCypher = entity.ToCypherString<T, CypherMatchAttribute>(CypherExtensionContext.Create(query), identifier, options.PropertyOverride);
+            var cql = string.Format("{0}({1}){2}", options.PreCql, matchCypher, options.PostCql);
+            dynamic cutdown = entity.CreateDynamic(options.PropertyOverride ?? CypherTypeItemHelper.PropertiesForPurpose<T, CypherMatchAttribute>(entity));
+
+            var matchKey = GetMatchParamName(identifier);
+
+            return matchFunction(query,cql)
+                    .WithParam(matchKey, cutdown);
+        }
+
 
         public static ICypherFluentQuery CreateEntity<T>(this ICypherFluentQuery query, T entity, string paramKey = null, List<CypherProperty> onCreateOverride = null, string preCql = "", string postCql = "") where T : class
         {

--- a/src/Neo4jClient.Extension/Cypher/MatchOptions.cs
+++ b/src/Neo4jClient.Extension/Cypher/MatchOptions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Neo4jClient.Extension.Cypher
+{
+    public class MatchOptions
+    {
+        public string Identifier { get; set; }
+
+        public string PreCql { get; set; }
+
+        public string PostCql { get; set; }
+
+        public List<CypherProperty> PropertyOverride { get; set; }
+
+        public MatchOptions()
+        {
+            PropertyOverride = null;
+        }
+
+        public static MatchOptions Create(string identifier)
+        {
+            return new MatchOptions {Identifier = identifier};
+        }
+    }
+
+    public static class MatchOptionExtensions
+    {
+        public static MatchOptions WithProperties(this MatchOptions target, List<CypherProperty> propertyOverride)
+        {
+            target.PropertyOverride = propertyOverride;
+            return target;
+        }
+
+        public static MatchOptions WithNoProperties(this MatchOptions target)
+        {
+            return WithProperties(target, new List<CypherProperty>());
+        }
+    }
+}

--- a/src/Neo4jClient.Extension/Cypher/MatchOptions.cs
+++ b/src/Neo4jClient.Extension/Cypher/MatchOptions.cs
@@ -14,11 +14,11 @@ namespace Neo4jClient.Extension.Cypher
 
         public string PostCql { get; set; }
 
-        public List<CypherProperty> PropertyOverride { get; set; }
+        public List<CypherProperty> MatchOverride { get; set; }
 
         public MatchOptions()
         {
-            PropertyOverride = null;
+            MatchOverride = null;
         }
 
         public static MatchOptions Create(string identifier)
@@ -31,7 +31,7 @@ namespace Neo4jClient.Extension.Cypher
     {
         public static MatchOptions WithProperties(this MatchOptions target, List<CypherProperty> propertyOverride)
         {
-            target.PropertyOverride = propertyOverride;
+            target.MatchOverride = propertyOverride;
             return target;
         }
 

--- a/src/Neo4jClient.Extension/Cypher/MatchRelationshipOptions.cs
+++ b/src/Neo4jClient.Extension/Cypher/MatchRelationshipOptions.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+namespace Neo4jClient.Extension.Cypher
+{
+    public class MatchRelationshipOptions
+    {
+        public List<CypherProperty> MatchOverride { get; set; }
+
+        public static MatchRelationshipOptions Create()
+        {
+            return new MatchRelationshipOptions();
+        }
+    }
+
+    public static class MatchRelationshipOptionsExtensions
+    {
+        public static MatchRelationshipOptions WithProperties(this MatchRelationshipOptions target, List<CypherProperty> propertyOverride)
+        {
+            target.MatchOverride = propertyOverride;
+            return target;
+        }
+
+        public static MatchRelationshipOptions WithNoProperties(this MatchRelationshipOptions target)
+        {
+            return WithProperties(target, new List<CypherProperty>());
+        }
+    }
+}

--- a/src/Neo4jClient.Extension/Neo4jClient.Extension.csproj
+++ b/src/Neo4jClient.Extension/Neo4jClient.Extension.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Cypher\Extension\CypherExtension.Entity.cs" />
     <Compile Include="Cypher\FluentConfig.cs" />
     <Compile Include="Cypher\MatchOptions.cs" />
+    <Compile Include="Cypher\MatchRelationshipOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Neo4jClient.Extension/Neo4jClient.Extension.csproj
+++ b/src/Neo4jClient.Extension/Neo4jClient.Extension.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Cypher\CypherTypeItemHelper.cs" />
     <Compile Include="Cypher\Extension\CypherExtension.Entity.cs" />
     <Compile Include="Cypher\FluentConfig.cs" />
+    <Compile Include="Cypher\MatchOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Neo4jClient.Extension.Test.Common/Neo/Relationships/AddressRelationships.cs
+++ b/test/Neo4jClient.Extension.Test.Common/Neo/Relationships/AddressRelationships.cs
@@ -19,7 +19,7 @@ namespace Neo4jClient.Extension.Test.TestEntities.Relationships
             DateEffective = effective;
         }
 
-        public HomeAddressRelationship(string from = "agent", string to = "address")
+        public HomeAddressRelationship(string from = "person", string to = "address")
             : base(from, to)
         {
         }

--- a/test/Neo4jClient.Extension.UnitTest/Cypher/FluentConfigMatchTests.cs
+++ b/test/Neo4jClient.Extension.UnitTest/Cypher/FluentConfigMatchTests.cs
@@ -46,6 +46,23 @@ namespace Neo4jClient.Extension.Test.Cypher
 OPTIONAL MATCH (ha:Address)", text);
         }
 
+        [Test]
+        public void OptionalMatchRelationship()
+        {
+            var person = SampleDataFactory.GetWellKnownPerson(7);
+            var homeAddressRelationship = new HomeAddressRelationship();
+            var q = GetFluentQuery()
+                .MatchEntity(person)
+                .OptionalMatchRelationship(homeAddressRelationship, MatchRelationshipOptions.Create().WithNoProperties());
+            var text = q.GetFormattedDebugText();
+            Console.WriteLine(text);
+
+            Assert.AreEqual(@"MATCH (person:SecretAgent {id:{
+  id: 7
+}.id})
+OPTIONAL MATCH (person)-[personaddress:HOME_ADDRESS]->(address)", text);
+        }
+
         [Test] 
         public void MatchRelationshipSimple()
         {

--- a/test/Neo4jClient.Extension.UnitTest/Cypher/FluentConfigMatchTests.cs
+++ b/test/Neo4jClient.Extension.UnitTest/Cypher/FluentConfigMatchTests.cs
@@ -30,6 +30,22 @@ namespace Neo4jClient.Extension.Test.Cypher
 }.id})", text);
         }
 
+        [Test]
+        public void OptionalMatchEntity()
+        {
+            var person = SampleDataFactory.GetWellKnownPerson(7);
+            var q = GetFluentQuery()
+                .MatchEntity(person)
+                .OptionalMatchEntity(person.HomeAddress, MatchOptions.Create("ha").WithNoProperties());
+            var text = q.GetFormattedDebugText();
+            Console.WriteLine(text);
+
+            Assert.AreEqual(@"MATCH (person:SecretAgent {id:{
+  id: 7
+}.id})
+OPTIONAL MATCH (ha:Address)", text);
+        }
+
         [Test] 
         public void MatchRelationshipSimple()
         {


### PR DESCRIPTION
A smaller set of improvements this time :)

* Added `MatchOptions.cs` to make it easier & neater to compose the match parameters.
 See [sample usage](https://github.com/simonpinn/Neo4jClient.Extension/compare/master...neutmute:round2?expand=1#diff-50c877303ac0fe80af124c8a2f1c8c38R39)
* Added `OptionalMatchRelationship` method
* Tests added

Have also started using the canonical term `identifier` instead of `paramKey` for those new bits